### PR TITLE
Fix: Update startup scripts to resolve dependency installation errors

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,7 @@
 @echo off
 pushd backend
-call pip install pydantic typing fastapi gdown py7zr
+call pip install --upgrade pip setuptools
+call pip install pydantic fastapi gdown py7zr
 REM To change the port, uncomment the line below and specify the desired port
 SET UVICORN_PORT=8000
 ECHO Starting server...

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,8 @@
 cd backend || exit
 
 # Install Python dependencies
-pip install pydantic typing fastapi gdown py7zr
+pip install --upgrade pip setuptools
+pip install pydantic fastapi gdown py7zr
 
 # Set the port (change this value as needed)
 UVICORN_PORT=8000


### PR DESCRIPTION
- Upgrades pip and setuptools before installing other packages.
- Removes 'typing' from explicit pip requirements as it's part of the standard library in modern Python versions.

These changes aim to fix an AttributeError related to 'pkgutil.ImpImporter' during 'typing' installation and ensure 'py7zr' is correctly installed and available to the application, resolving a ModuleNotFoundError.